### PR TITLE
Introduce AclGen object

### DIFF
--- a/aclgen.py
+++ b/aclgen.py
@@ -61,6 +61,29 @@ class AclGen(object):
   Given inputs, generates ACLs to output stream or filesystem.
   """
 
+  def __init__(self,
+               policy_directory,
+               definitions_directory,
+               output_directory,
+               shade_check = False,
+               expiry_info = 2):
+    """Constructor.
+
+    Args:
+      policy_directory: string, path to the policies
+      definitions_directory: string, path to the definitions
+      output_directory: string, base directory for generated ACLs
+      shade_check: True/False, whether or not to do a shade check
+      expiry_info: int, expiry weeks.
+    """
+
+    self.policy_directory = policy_directory
+    self.definitions_directory = definitions_directory
+    self.output_directory = output_directory
+    self.shade_check = shade_check
+    self.expiry_info = expiry_info
+
+
   _memoized_defs = {}
   def _create_defs(self, defs_directory):
     """Creates naming.Naming object using the contents of the supplied directory.
@@ -264,25 +287,43 @@ def parse_args(command_line_args):
 
 
 def load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir):
-  aclgen = AclGen()
+  aclgen = AclGen(policy_directory = base_dir,
+                  definitions_directory = defs_directory,
+                  output_directory = output_dir,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
   return aclgen.load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir)
 
 def filter_name(base_dir, source, suffix, output_directory):
   return AclGen.filter_name(base_dir, source, suffix, output_directory)
 
 def render_filters(source_file, defs_directory, shade_check, exp_info, output_dir):
-  aclgen = AclGen()
+  p, f = os.path.split(source_file)
+  aclgen = AclGen(policy_directory = p,
+                  definitions_directory = defs_directory,
+                  output_directory = output_dir,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
   return aclgen.render_filters(source_file, defs_directory, shade_check, exp_info, output_dir)
 
 def create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info):
-  aclgen = AclGen()
+  p, f = os.path.split(source_file)
+  aclgen = AclGen(policy_directory = p,
+                  definitions_directory = defs_directory,
+                  output_directory = None,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
   return aclgen.create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info)
 
 
 def main(args):
   FLAGS = parse_args(args)
 
-  gen = AclGen()
+  gen = AclGen(policy_directory = FLAGS.policy_directory,
+               definitions_directory = FLAGS.definitions,
+               output_directory = FLAGS.output_directory,
+               shade_check = FLAGS.shade_check,
+               expiry_info = FLAGS.exp_info)
 
   count = 0
   if FLAGS.policy_directory:

--- a/aclgen.py
+++ b/aclgen.py
@@ -83,8 +83,9 @@ class AclGen(object):
     self.shade_check = shade_check
     self.expiry_info = expiry_info
 
+    # A naming.Naming object created with self._create_defs()
+    self.__memoized_defs = None
 
-  _memoized_defs = {}
   def _create_defs(self):
     """Creates naming.Naming object using the contents of the supplied directory.
 
@@ -92,18 +93,17 @@ class AclGen(object):
     can be restricted to strings and ints, versus domain objects.  This promotes
     use of this module for other clients."""
 
-    if self.definitions_directory in self._memoized_defs:
-      return self._memoized_defs[self.definitions_directory]
+    if self.__memoized_defs is not None:
+      return self.__memoized_defs
 
     if not os.path.exists(self.definitions_directory):
       msg = 'missing defs directory {0}'.format(self.definitions_directory)
       raise ValueError(msg)
-    defs = naming.Naming(self.definitions_directory)
-    if not defs:
+    self.__memoized_defs = naming.Naming(self.definitions_directory)
+    if not self.__memoized_defs:
       raise ValueError('problem loading definitions')
 
-    self._memoized_defs[self.definitions_directory] = defs
-    return defs
+    return self.__memoized_defs
 
   def load_and_render(self):
     return self._do_load_and_render(self.policy_directory, self.policy_directory)

--- a/aclgen.py
+++ b/aclgen.py
@@ -284,7 +284,8 @@ def _create_defs(defs_directory):
   return defs
 
 def load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir):
-  return _do_load_and_render(base_dir, base_dir, defs_directory, shade_check, exp_info, output_dir)
+  aclgen = AclGen()
+  return aclgen.load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir)
 
 def _do_load_and_render(base_dir, curr_dir, defs_directory, shade_check, exp_info, output_dir):
   rendered = 0
@@ -300,30 +301,7 @@ def _do_load_and_render(base_dir, curr_dir, defs_directory, shade_check, exp_inf
 
 
 def filter_name(base_dir, source, suffix, output_directory):
-  """Create an output filename for the filter.
-
-  The output filename is such that the directory structure
-  of `output_directory` matches the directory structure of
-  the `source` relative to the `base_dir`.  For example,
-  with the following:
-
-  - `base_dir` = 'hi/there/'
-  - source = 'hi/there/SOME/file.txt'
-  - suffix = '.suff'
-  - output_directory 'newlocation'
-
-  the returned directory would be
-
-    'newlocation/SOME/file.suff.'
-  """
-  abs_source = os.path.abspath(source)
-  abs_base = os.path.abspath(base_dir) + '/'
-  if not abs_source.startswith(abs_base):
-    raise ValueError('{0} is not in base dir {1}'.format(abs_source, abs_base))
-  rel_from_base = abs_source.replace(abs_base, '')
-  reldir, fname = os.path.split(rel_from_base)
-  fname = '%s%s' % ('.'.join(fname.split('.')[0:-1]), suffix)
-  return os.path.join(output_directory, reldir, fname)
+  return AclGen.filter_name(base_dir, source, suffix, output_directory)
 
 
 def do_output_filter(filter_text, filter_file):
@@ -346,50 +324,13 @@ def get_policy_obj(source_file, defs_directory, optimize, shade_check):
 
 
 def render_filters(source_file, defs_directory, shade_check, exp_info, output_dir):
-  base_dir = os.path.dirname(os.path.abspath(source_file))
-  return _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir)
+  aclgen = AclGen()
+  return aclgen.render_filters(source_file, defs_directory, shade_check, exp_info, output_dir)
 
 
 def create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info):
-  """Render platform specific filter for a policy.
-
-  Use the platform's renderer to render its filter, using its
-  own separate copy of the policy object and with optional, target
-  specific attributes such as optimization."""
-
-  supported_targets = {
-    'arista': {'optimized': True, 'renderer': arista.Arista},
-    'aruba': {'optimized': True, 'renderer': aruba.Aruba},
-    'brocade': {'optimized': True, 'renderer': brocade.Brocade},
-    'cisco': {'optimized': True, 'renderer': cisco.Cisco},
-    'ciscoasa': {'optimized': True, 'renderer': ciscoasa.CiscoASA},
-    'ciscoxr': {'optimized': True, 'renderer': ciscoxr.CiscoXR},
-    'demo': {'optimized': True, 'renderer': demo.Demo},
-    'gce': {'optimized': True, 'renderer': gce.GCE},
-    'ipset': {'optimized': True, 'renderer': ipset.Ipset},
-    'iptables': {'optimized': True, 'renderer': iptables.Iptables},
-    'juniper': {'optimized': True, 'renderer': juniper.Juniper},
-    'junipersrx': {'optimized': False, 'renderer': junipersrx.JuniperSRX},
-    'nsxv': {'optimized': True, 'renderer': nsxv.Nsxv},
-    'packetfilter': {'optimized': True, 'renderer': packetfilter.PacketFilter},
-    'speedway': {'optimized': True, 'renderer': speedway.Speedway},
-    'srx': {'optimized': False, 'renderer': junipersrx.JuniperSRX},
-  }
-
-  this_platform = supported_targets.get(platform)
-  if this_platform is None:
-    raise policy.PolicyTargetPlatformInvalidError('unsupported platform {0}'.format(platform))
-
-  optimized = this_platform['optimized']
-  pol = copy.deepcopy(get_policy_obj(source_file, defs_directory,
-                                     optimized, shade_check))
-
-  if platform not in pol.platforms:
-    msg = 'platform {0} not in policy targets {1}'.format(platform, pol.platforms)
-    raise policy.PolicyTargetPlatformInvalidError(msg)
-
-  renderer = this_platform['renderer']
-  return renderer(pol, exp_info)
+  aclgen = AclGen()
+  return aclgen.create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info)
 
 
 def _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir):

--- a/aclgen.py
+++ b/aclgen.py
@@ -430,13 +430,15 @@ def _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_i
 def main(args):
   FLAGS = parse_args(args)
 
+  gen = AclGen()
+
   count = 0
   if FLAGS.policy_directory:
-    count = load_and_render(FLAGS.policy_directory, FLAGS.definitions, FLAGS.shade_check,
+    count = gen.load_and_render(FLAGS.policy_directory, FLAGS.definitions, FLAGS.shade_check,
                             FLAGS.exp_info, FLAGS.output_directory)
 
   elif FLAGS.policy:
-    count = render_filters(FLAGS.policy, FLAGS.definitions, FLAGS.shade_check,
+    count = gen.render_filters(FLAGS.policy, FLAGS.definitions, FLAGS.shade_check,
                            FLAGS.exp_info, FLAGS.output_directory)
 
   print '%d filters rendered' % count

--- a/aclgen.py
+++ b/aclgen.py
@@ -62,7 +62,7 @@ class AclGen(object):
   """
 
   _memoized_defs = {}
-  def _create_defs(defs_directory):
+  def _create_defs(self, defs_directory):
     """Creates naming.Naming object using the contents of the supplied directory.
 
     The created defs object is memoized so that the public API of this module
@@ -82,10 +82,10 @@ class AclGen(object):
     _memoized_defs[defs_directory] = defs
     return defs
 
-  def load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir):
+  def load_and_render(self, base_dir, defs_directory, shade_check, exp_info, output_dir):
     return _do_load_and_render(base_dir, base_dir, defs_directory, shade_check, exp_info, output_dir)
 
-  def _do_load_and_render(base_dir, curr_dir, defs_directory, shade_check, exp_info, output_dir):
+  def _do_load_and_render(self, base_dir, curr_dir, defs_directory, shade_check, exp_info, output_dir):
     rendered = 0
     for dirfile in dircache.listdir(curr_dir):
       fname = os.path.join(curr_dir, dirfile)
@@ -97,7 +97,7 @@ class AclGen(object):
         rendered += _do_render_filters(base_dir, fname, defs_directory, shade_check, exp_info, output_dir)
     return rendered
 
-
+  @staticmethod
   def filter_name(base_dir, source, suffix, output_directory):
     """Create an output filename for the filter.
 
@@ -125,7 +125,7 @@ class AclGen(object):
     return os.path.join(output_directory, reldir, fname)
 
 
-  def do_output_filter(filter_text, filter_file):
+  def do_output_filter(self, filter_text, filter_file):
     if not os.path.isdir(os.path.dirname(filter_file)):
       os.makedirs(os.path.dirname(filter_file))
     output = open(filter_file, 'w')
@@ -134,7 +134,7 @@ class AclGen(object):
       output.write(filter_text)
 
 
-  def get_policy_obj(source_file, defs_directory, optimize, shade_check):
+  def get_policy_obj(self, source_file, defs_directory, optimize, shade_check):
     """Memoized call to parse policy by file name.
 
     Returns parsed policy object.
@@ -144,12 +144,12 @@ class AclGen(object):
                                  shade_check=shade_check)
 
 
-  def render_filters(source_file, defs_directory, shade_check, exp_info, output_dir):
+  def render_filters(self, source_file, defs_directory, shade_check, exp_info, output_dir):
     base_dir = os.path.dirname(os.path.abspath(source_file))
     return _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir)
 
 
-  def create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info):
+  def create_filter_for_platform(self, platform, source_file, defs_directory, shade_check, exp_info):
     """Render platform specific filter for a policy.
 
     Use the platform's renderer to render its filter, using its
@@ -191,7 +191,7 @@ class AclGen(object):
     return renderer(pol, exp_info)
 
 
-  def _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir):
+  def _do_render_filters(self, base_dir, source_file, defs_directory, shade_check, exp_info, output_dir):
     """Render platform specfic filters for each target platform.
 
     For each target specified in each header of the policy, use that

--- a/aclgen.py
+++ b/aclgen.py
@@ -247,6 +247,42 @@ class AclGen(object):
     return count
 
 
+########
+# Backwards compatibility wrappers of AclGen methods.
+
+def load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir):
+  aclgen = AclGen(policy_directory = base_dir,
+                  definitions_directory = defs_directory,
+                  output_directory = output_dir,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
+  return aclgen.load_and_render()
+
+def filter_name(base_dir, source, suffix, output_directory):
+  return AclGen.filter_name(base_dir, source, suffix, output_directory)
+
+def render_filters(source_file, defs_directory, shade_check, exp_info, output_dir):
+  p, f = os.path.split(source_file)
+  aclgen = AclGen(policy_directory = p,
+                  definitions_directory = defs_directory,
+                  output_directory = output_dir,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
+  return aclgen.render_filters(source_file)
+
+def create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info):
+  p, f = os.path.split(source_file)
+  aclgen = AclGen(policy_directory = p,
+                  definitions_directory = defs_directory,
+                  output_directory = None,
+                  shade_check = shade_check,
+                  expiry_info = exp_info)
+  return aclgen.create_filter_for_platform(platform, source_file)
+
+
+########
+# Main
+
 def parse_args(command_line_args):
   """Populate flags from the command-line arguments."""
   _parser = OptionParser()
@@ -282,36 +318,6 @@ def parse_args(command_line_args):
     raise ValueError('no definitions supplied')
 
   return flags
-
-
-def load_and_render(base_dir, defs_directory, shade_check, exp_info, output_dir):
-  aclgen = AclGen(policy_directory = base_dir,
-                  definitions_directory = defs_directory,
-                  output_directory = output_dir,
-                  shade_check = shade_check,
-                  expiry_info = exp_info)
-  return aclgen.load_and_render()
-
-def filter_name(base_dir, source, suffix, output_directory):
-  return AclGen.filter_name(base_dir, source, suffix, output_directory)
-
-def render_filters(source_file, defs_directory, shade_check, exp_info, output_dir):
-  p, f = os.path.split(source_file)
-  aclgen = AclGen(policy_directory = p,
-                  definitions_directory = defs_directory,
-                  output_directory = output_dir,
-                  shade_check = shade_check,
-                  expiry_info = exp_info)
-  return aclgen.render_filters(source_file)
-
-def create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info):
-  p, f = os.path.split(source_file)
-  aclgen = AclGen(policy_directory = p,
-                  definitions_directory = defs_directory,
-                  output_directory = None,
-                  shade_check = shade_check,
-                  expiry_info = exp_info)
-  return aclgen.create_filter_for_platform(platform, source_file)
 
 
 def main(args):

--- a/aclgen.py
+++ b/aclgen.py
@@ -69,8 +69,8 @@ class AclGen(object):
     can be restricted to strings and ints, versus domain objects.  This promotes
     use of this module for other clients."""
 
-    if defs_directory in _memoized_defs:
-      return _memoized_defs[defs_directory]
+    if defs_directory in self._memoized_defs:
+      return self._memoized_defs[defs_directory]
 
     if not os.path.exists(defs_directory):
       msg = 'missing defs directory {0}'.format(defs_directory)
@@ -79,11 +79,11 @@ class AclGen(object):
     if not defs:
       raise ValueError('problem loading definitions')
 
-    _memoized_defs[defs_directory] = defs
+    self._memoized_defs[defs_directory] = defs
     return defs
 
   def load_and_render(self, base_dir, defs_directory, shade_check, exp_info, output_dir):
-    return _do_load_and_render(base_dir, base_dir, defs_directory, shade_check, exp_info, output_dir)
+    return self._do_load_and_render(base_dir, base_dir, defs_directory, shade_check, exp_info, output_dir)
 
   def _do_load_and_render(self, base_dir, curr_dir, defs_directory, shade_check, exp_info, output_dir):
     rendered = 0
@@ -91,10 +91,10 @@ class AclGen(object):
       fname = os.path.join(curr_dir, dirfile)
       #logging.debug('load_and_render working with fname %s', fname)
       if os.path.isdir(fname):
-        rendered += _do_load_and_render(base_dir, fname, defs_directory, shade_check, exp_info, output_dir)
+        rendered += self._do_load_and_render(base_dir, fname, defs_directory, shade_check, exp_info, output_dir)
       elif fname.endswith('.pol'):
         #logging.debug('attempting to render_filters on fname %s', fname)
-        rendered += _do_render_filters(base_dir, fname, defs_directory, shade_check, exp_info, output_dir)
+        rendered += self._do_render_filters(base_dir, fname, defs_directory, shade_check, exp_info, output_dir)
     return rendered
 
   @staticmethod
@@ -139,14 +139,14 @@ class AclGen(object):
 
     Returns parsed policy object.
     """
-    definitions_obj = _create_defs(defs_directory)
+    definitions_obj = self._create_defs(defs_directory)
     return policyparser.CacheParseFile(source_file, definitions_obj, optimize,
                                  shade_check=shade_check)
 
 
   def render_filters(self, source_file, defs_directory, shade_check, exp_info, output_dir):
     base_dir = os.path.dirname(os.path.abspath(source_file))
-    return _do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir)
+    return self._do_render_filters(base_dir, source_file, defs_directory, shade_check, exp_info, output_dir)
 
 
   def create_filter_for_platform(self, platform, source_file, defs_directory, shade_check, exp_info):
@@ -180,7 +180,7 @@ class AclGen(object):
       raise policy.PolicyTargetPlatformInvalidError('unsupported platform {0}'.format(platform))
 
     optimized = this_platform['optimized']
-    pol = copy.deepcopy(get_policy_obj(source_file, defs_directory,
+    pol = copy.deepcopy(self.get_policy_obj(source_file, defs_directory,
                                        optimized, shade_check))
 
     if platform not in pol.platforms:
@@ -209,18 +209,18 @@ class AclGen(object):
     """
 
     # Get a policy object from cache to determine headers within the policy file.
-    pol = get_policy_obj(source_file, defs_directory, True, shade_check)
+    pol = self.get_policy_obj(source_file, defs_directory, True, shade_check)
 
     count = 0
 
     for header in pol.headers:
       for platform in header.platforms:
 
-        fw = create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info)
+        fw = self.create_filter_for_platform(platform, source_file, defs_directory, shade_check, exp_info)
 
-        filter_file = filter_name(base_dir, source_file, fw._SUFFIX, output_dir)
+        filter_file = AclGen.filter_name(base_dir, source_file, fw._SUFFIX, output_dir)
         filter_text = str(fw)
-        do_output_filter(filter_text, filter_file)
+        self.do_output_filter(filter_text, filter_file)
         count += 1
 
     return count

--- a/test/integration/test_aclgen.py
+++ b/test/integration/test_aclgen.py
@@ -172,10 +172,15 @@ class AclGen_Characterization_Tests(AclGen_Characterization_Test_Base):
 class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
   """Given a policy, generate filter text for a particular target."""
 
+  def get_acl_gen(self):
+    return AclGen(policy_directory = self.testpath('policies'),
+                  definitions_directory = self.testpath('def'),
+                  output_directory = self.testpath('filters_expected'))
+
   def test_can_generate_filter_from_policy_for_specified_platform(self):
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
-    a = AclGen()
+    a = self.get_acl_gen()
     fw = a.create_filter_for_platform('cisco', src, definitions, False, 2)
     actual_filter = str(fw)
     with open(self.testpath('filters_expected', 'sample_cisco_lab.acl'), 'r') as f:
@@ -183,12 +188,12 @@ class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
     self.assertEquals(actual_filter, expected_filter)
 
   def test_generating_filter_for_missing_platform_throws(self):
-    a = AclGen()
+    a = self.get_acl_gen()
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):
       a.create_filter_for_platform('missing', '', None, False, 2)
 
   def test_cannot_generate_filter_from_policy_for_platform_different_from_policy_header(self):
-    a = AclGen()
+    a = self.get_acl_gen()
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):

--- a/test/integration/test_aclgen.py
+++ b/test/integration/test_aclgen.py
@@ -148,6 +148,25 @@ class AclGen_Characterization_Tests(AclGen_Characterization_Test_Base):
     self.assertEquals([], dircmp.right_only, 'missing {0} in filters_actual'.format(dircmp.right_only))
     self.assertEquals([], dircmp.diff_files)
 
+  def test_can_make_direct_API_call_to_load_and_render(self):
+    """Existing clients may have been making calls directly
+    to aclgen.load_and_render, double-checking it still works."""
+    def_dir, pol_dir, expected_dir = map(self.testpath, ('def', 'policies', 'filters_expected'))
+    aclgen.load_and_render(pol_dir, def_dir, False, 2, self.output_dir)
+
+    dircmp = filecmp.dircmp(self.output_dir, expected_dir)
+    self.assertEquals([], dircmp.left_only, 'missing {0} in filters_expected'.format(dircmp.left_only))
+    self.assertEquals([], dircmp.right_only, 'missing {0} in filters_actual'.format(dircmp.right_only))
+    self.assertEquals([], dircmp.diff_files)
+
+  def test_can_make_direct_API_call_to_render_filters(self):
+    """Existing clients may have been making calls directly
+    to aclgen.render_filters, double-checking it still works."""
+    def_dir, pol_dir, expected_dir = map(self.testpath, ('def', 'policies', 'filters_expected'))
+    src = os.path.join(pol_dir, 'sample_cisco_lab.pol')
+    aclgen.render_filters(src, def_dir, False, 2, self.output_dir)
+    # If we get here, assume all is OK.
+
 
 class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
   """Given a policy, generate filter text for a particular target."""

--- a/test/integration/test_aclgen.py
+++ b/test/integration/test_aclgen.py
@@ -7,6 +7,7 @@ from cStringIO import StringIO
 import filecmp
 
 import aclgen
+from aclgen import AclGen
 from lib import policy
 
 class Test_AclGen(unittest.TestCase):
@@ -75,27 +76,27 @@ class AclGen_filter_name_scenarios(unittest.TestCase):
   See aclgen.filter_name for notes."""
 
   def test_file_in_base_directory_is_output_to_output_dir(self):
-    s = aclgen.filter_name('/policy', '/policy/x.txt', '.out', '/output')
+    s = AclGen.filter_name('/policy', '/policy/x.txt', '.out', '/output')
     self.assertEqual(s, '/output/x.out')
 
   def test_file_in_subdirectory_is_output_to_subdirectory(self):
-    s = aclgen.filter_name('/policy', '/policy/subdir/x.txt', '.out', '/output')
+    s = AclGen.filter_name('/policy', '/policy/subdir/x.txt', '.out', '/output')
     self.assertEqual(s, '/output/subdir/x.out')
 
   def test_file_in_nested_subdir(self):
-    s = aclgen.filter_name('/policy', '/policy/sub/dir/x.txt', '.out', '/output/here')
+    s = AclGen.filter_name('/policy', '/policy/sub/dir/x.txt', '.out', '/output/here')
     self.assertEqual(s, '/output/here/sub/dir/x.out')
 
   def test_relative_directory_structure_mirrored(self):
-    s = aclgen.filter_name('../policy', '../policy/subdir/x.txt', '.out', '/output')
+    s = AclGen.filter_name('../policy', '../policy/subdir/x.txt', '.out', '/output')
     self.assertEqual(s, '/output/subdir/x.out')
 
   def test_empty_source_dir_ok(self):
-    s = aclgen.filter_name('', 'subdir/x.txt', '.out', '/output')
+    s = AclGen.filter_name('', 'subdir/x.txt', '.out', '/output')
     self.assertEqual(s, '/output/subdir/x.out')
 
   def test_base_dir_must_match_start_of_source_file(self):
-    self.assertRaises(ValueError, aclgen.filter_name, 'A', 'B/C', 'suff', 'O')
+    self.assertRaises(ValueError, AclGen.filter_name, 'A', 'B/C', 'suff', 'O')
 
 
 class AclGen_Characterization_Test_Base(unittest.TestCase):
@@ -174,21 +175,24 @@ class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
   def test_can_generate_filter_from_policy_for_specified_platform(self):
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
-    fw = aclgen.create_filter_for_platform('cisco', src, definitions, False, 2)
+    a = AclGen()
+    fw = a.create_filter_for_platform('cisco', src, definitions, False, 2)
     actual_filter = str(fw)
     with open(self.testpath('filters_expected', 'sample_cisco_lab.acl'), 'r') as f:
       expected_filter = f.read()
     self.assertEquals(actual_filter, expected_filter)
 
   def test_generating_filter_for_missing_platform_throws(self):
+    a = AclGen()
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):
-      aclgen.create_filter_for_platform('missing', '', None, False, 2)
+      a.create_filter_for_platform('missing', '', None, False, 2)
 
   def test_cannot_generate_filter_from_policy_for_platform_different_from_policy_header(self):
+    a = AclGen()
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):
-      aclgen.create_filter_for_platform('juniper', src, definitions, False, 2)
+      a.create_filter_for_platform('juniper', src, definitions, False, 2)
 
 
 def main():

--- a/test/integration/test_aclgen.py
+++ b/test/integration/test_aclgen.py
@@ -181,7 +181,7 @@ class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
     a = self.get_acl_gen()
-    fw = a.create_filter_for_platform('cisco', src, definitions, False, 2)
+    fw = a.create_filter_for_platform('cisco', src)
     actual_filter = str(fw)
     with open(self.testpath('filters_expected', 'sample_cisco_lab.acl'), 'r') as f:
       expected_filter = f.read()
@@ -190,14 +190,14 @@ class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
   def test_generating_filter_for_missing_platform_throws(self):
     a = self.get_acl_gen()
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):
-      a.create_filter_for_platform('missing', '', None, False, 2)
+      a.create_filter_for_platform('missing', '')
 
   def test_cannot_generate_filter_from_policy_for_platform_different_from_policy_header(self):
     a = self.get_acl_gen()
     src = self.testpath('policies', 'sample_cisco_lab.pol')
     definitions = self.testpath('def')
     with self.assertRaises(policy.PolicyTargetPlatformInvalidError):
-      a.create_filter_for_platform('juniper', src, definitions, False, 2)
+      a.create_filter_for_platform('juniper', src)
 
 
 def main():


### PR DESCRIPTION
Preparatory work for introducing new parsers.

ACL generation needs to be able to work with different data parsers.  This work will let us substitute in a different parser (to support different grammars, different input file requirements, etc).  Some methods from aclgen.py are left as module-level methods (which delegate to the AclGen object) for backwards compatibility.
