### PR TITLE
Add Cisco Nexus support.

### DIFF
--- a/aclgen.py
+++ b/aclgen.py
@@ -43,6 +43,7 @@ from lib import brocade
 from lib import cisco
 from lib import ciscoasa
 from lib import ciscoxr
+from lib import cisconx
 from lib import gce
 from lib import iptables
 from lib import ipset
@@ -197,6 +198,7 @@ class AclGen(object):
       'cisco': {'optimized': True, 'renderer': cisco.Cisco},
       'ciscoasa': {'optimized': True, 'renderer': ciscoasa.CiscoASA},
       'ciscoxr': {'optimized': True, 'renderer': ciscoxr.CiscoXR},
+      'cisconx': {'optimized': True, 'renderer':cisconx.CiscoNX},
       'demo': {'optimized': True, 'renderer': demo.Demo},
       'gce': {'optimized': True, 'renderer': gce.GCE},
       'ipset': {'optimized': True, 'renderer': ipset.Ipset},

--- a/lib/cisco.py
+++ b/lib/cisco.py
@@ -386,7 +386,7 @@ class Term(aclgenerator.Term):
       if self._PLATFORM in self.term.platform_exclude:
         return ''
 
-    ret_str = ['']
+    ret_str = ['\n']
 
     # Don't render icmpv6 protocol terms under inet, or icmp under inet6
     if (
@@ -873,6 +873,9 @@ class Cisco(aclgenerator.ACLGenerator):
   def __str__(self):
     target_header = []
     target = []
+    # add the p4 tags
+    target.extend(aclgenerator.AddRepositoryTags('! '))
+
     for (header, filter_name, filter_list, terms, obj_target
         ) in self.cisco_policies:
       for filter_type in filter_list:
@@ -896,7 +899,6 @@ class Cisco(aclgenerator.ACLGenerator):
         for comment in header.comment:
           for line in comment.split('\n'):
             target.append(' remark %s' % line)
-        target.append(' remark Filter type is %s' % (filter_type))
 
         # now add the terms
         for term in terms:

--- a/lib/cisco.py
+++ b/lib/cisco.py
@@ -301,11 +301,6 @@ class ObjectGroupTerm(aclgenerator.Term):
     # protocol
     if not self.term.protocol:
       protocol = ['ip']
-    else:
-      pass
-      # pylint: disable=g-long-lambda
-      #protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
-      # pylint: enable=g-long-lambda
 
     # addresses
     source_address = self.term.source_address
@@ -422,11 +417,6 @@ class Term(aclgenerator.Term):
         protocol = ['ip']
     elif self.term.protocol == ['hop-by-hop']:
       protocol = ['hbh']
-    elif self.proto_int:
-      pass
-      # pylint: disable=g-long-lambda
-      #protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
-      # pylint: enable=g-long-lambda
     else:
       protocol = self.term.protocol
     # source address

--- a/lib/cisco.py
+++ b/lib/cisco.py
@@ -28,7 +28,6 @@ from third_party import ipaddr
 import aclgenerator
 import nacaddr
 
-
 _ACTION_TABLE = {
     'accept': 'permit',
     'deny': 'deny',
@@ -141,12 +140,12 @@ class TermStandard(object):
                                                    'any', self.logstring))
 
     else:
-      ret_str.append('remark ' + self.term.name)
+      ret_str.append(' remark ' + self.term.name)
       comment_max_width = 70
       comments = aclgenerator.WrapWords(self.term.comment, comment_max_width)
       if comments and comments[0]:
         for comment in comments:
-          ret_str.append('remark ' + str(comment))
+          ret_str.append(' remark ' + str(comment))
 
       action = _ACTION_TABLE.get(str(self.term.action[0]))
       if v4_addresses:
@@ -263,7 +262,7 @@ class ObjectGroupTerm(aclgenerator.Term):
   """
   _PLATFORM = 'cisco'
   # Protocols should be emitted as integers rather than strings.
-  _PROTO_INT = True
+  _PROTO_INT = False
 
   def __init__(self, term, filter_name):
     super(ObjectGroupTerm, self).__init__(term)
@@ -284,12 +283,12 @@ class ObjectGroupTerm(aclgenerator.Term):
     destination_address_dict = {}
 
     ret_str = ['\n']
-    ret_str.append('remark %s' % self.term.name)
+    ret_str.append(' remark %s' % self.term.name)
     comment_max_width = 70
     comments = aclgenerator.WrapWords(self.term.comment, comment_max_width)
     if comments and comments[0]:
       for comment in comments:
-        ret_str.append('remark %s' % str(comment))
+        ret_str.append(' remark %s' % str(comment))
 
     # Term verbatim output - this will skip over normal term creation
     # code by returning early.  Warnings provided in policy.py.
@@ -303,8 +302,9 @@ class ObjectGroupTerm(aclgenerator.Term):
     if not self.term.protocol:
       protocol = ['ip']
     else:
+      pass
       # pylint: disable=g-long-lambda
-      protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
+      #protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
       # pylint: enable=g-long-lambda
 
     # addresses
@@ -359,6 +359,7 @@ class ObjectGroupTerm(aclgenerator.Term):
 
 class Term(aclgenerator.Term):
   """A single ACL Term."""
+  _TCP = 'tcp'
 
   _PLATFORM = 'cisco'
 
@@ -385,22 +386,24 @@ class Term(aclgenerator.Term):
       if self._PLATFORM in self.term.platform_exclude:
         return ''
 
-    ret_str = ['\n']
+    ret_str = ['']
 
     # Don't render icmpv6 protocol terms under inet, or icmp under inet6
-    if ((self.af == 6 and 'icmp' in self.term.protocol) or
+    if (
         (self.af == 4 and 'icmpv6' in self.term.protocol)):
       logging.debug(self.NO_AF_LOG_PROTO.substitute(term=self.term.name,
                                                     proto=self.term.protocol,
                                                     af=self.text_af))
       return ''
 
-    ret_str.append('remark ' + self.term.name)
+    ret_str.append(' remark ' + self.term.name)
+    if self.term.owner:
+      self.term.comment.append('Owner: %s' % self.term.owner)
     if self.term.owner:
       self.term.comment.append('Owner: %s' % self.term.owner)
     for comment in self.term.comment:
       for line in comment.split('\n'):
-        ret_str.append('remark ' + str(line)[:100])
+        ret_str.append(' remark ' + str(line)[:100])
 
     # Term verbatim output - this will skip over normal term creation
     # code by returning early.  Warnings provided in policy.py.
@@ -411,6 +414,7 @@ class Term(aclgenerator.Term):
         return '\n'.join(ret_str)
 
     # protocol
+    protocol = self.term.protocol
     if not self.term.protocol:
       if self.af == 6:
         protocol = ['ipv6']
@@ -419,8 +423,9 @@ class Term(aclgenerator.Term):
     elif self.term.protocol == ['hop-by-hop']:
       protocol = ['hbh']
     elif self.proto_int:
+      pass
       # pylint: disable=g-long-lambda
-      protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
+      #protocol = map(self.PROTO_MAP.get, self.term.protocol, self.term.protocol)
       # pylint: enable=g-long-lambda
     else:
       protocol = self.term.protocol
@@ -504,6 +509,135 @@ class Term(aclgenerator.Term):
 
     return '\n'.join(ret_str)
 
+  def _TermPortToProtocol (self,portNumber,proto):
+
+    _IOS_PORTS_TCP = {
+179: "bgp",
+19: "chargen",
+514: "cmd",
+13: "daytime",
+9: "discard",
+53: "domain",
+7: "echo",
+512: "exec",
+79: "finger",
+21: "ftp",
+20: "ftp-data",
+70: "gopher",
+101: "hostname",
+113: "ident",
+194: "irc",
+543: "klogin",
+544: "kshell",
+513: "login",
+515: "lpd",
+119: "nntp",
+496: "pim-auto-rp",
+109: "pop2",
+110: "pop3",
+25: "smtp",
+111: "sunrpc",
+49: "tacacs",
+517: "talk",
+23: "telnet",
+37: "time",
+540: "uucp",
+43: "whois",
+80: "www"
+}
+
+    _IOS_PORTS_UDP = {
+512: "biff",
+68: "bootpc",
+67: "bootps",
+9: "discard",
+195: "dnsix",
+53: "domain",
+7: "echo",
+500: "isakmp",
+434: "mobile-ip",
+42: "nameserver",
+138: "netbios-dgm",
+137: "netbios-ns",
+139: "netbios-ss",
+4500: "non500-isakmp",
+123: "ntp",
+496: "pim-auto-rp",
+520: "rip",
+161: "snmp",
+162: "snmptrap",
+111: "sunrpc",
+514: "syslog",
+49: "tacacs",
+517: "talk",
+69: "tftp",
+37: "time",
+513: "who",
+177: "xdmcp",
+}
+
+    _CISCO_TYPES_ICMP = {
+6:  "alternate-address",
+31: "conversion-error",
+8:  "echo",
+0:  "echo-reply",
+16: "information-reply",
+15: "information-request",
+18: "mask-reply",
+17: "mask-request",
+32: "mobile-redirect",
+12: "parameter-problem",
+5:  "redirect",
+9:  "router-advertisement",
+10: "router-solicitation",
+4:  "source-quench",
+11: "time-exceeded",
+14: "timestamp-reply",
+13: "timestamp-request",
+30: "traceroute",
+3:  "unreachable"
+}
+
+    _CISCO_TYPES_ICMPv6 = {
+1: "unreachable",
+2: "packet-too-big",
+3: "time-exceeded",
+4: "parameter-problem",
+128: "echo-request",
+129: "echo-reply"
+}
+
+    if proto == "tcp":
+      if portNumber in _IOS_PORTS_TCP:
+        return _IOS_PORTS_TCP[portNumber]
+    elif proto == "udp":
+      if portNumber in _IOS_PORTS_UDP:
+        return _IOS_PORTS_UDP[portNumber]
+    elif proto == "icmp": 
+      if self.af == 4:
+        if portNumber in _CISCO_TYPES_ICMP: 
+          return _CISCO_TYPES_ICMP[portNumber]
+      elif self.af == 6:
+        if portNumber in _CISCO_TYPES_ICMPv6: 
+          return _CISCO_TYPES_ICMPv6[portNumber]
+
+    return portNumber
+
+  def _AddressToStr(self, addr):
+    # inet4
+    if type(addr) is nacaddr.IPv4 or type(addr) is ipaddr.IPv4Network:
+      if addr.numhosts > 1:
+        addr = '%s %s' % (addr.ip, addr.hostmask)
+      else:
+        addr = 'host %s' % (addr.ip)
+    # inet6
+    if type(addr) is nacaddr.IPv6 or type(addr) is ipaddr.IPv6Network:
+      if addr.numhosts > 1:
+        addr = '%s' % (addr.with_prefixlen)
+      else:
+        addr = 'host %s' % (addr.ip)
+    return addr
+
   def _TermletToStr(self, action, proto, saddr, sport, daddr, dport,
                     icmp_type, option):
     """Take the various compenents and turn them into a cisco acl line.
@@ -524,43 +658,23 @@ class Term(aclgenerator.Term):
     Raises:
       UnsupportedCiscoAccessListError: When unknown icmp-types specified
     """
-    # inet4
-    if type(saddr) is nacaddr.IPv4 or type(saddr) is ipaddr.IPv4Network:
-      if saddr.numhosts > 1:
-        saddr = '%s %s' % (saddr.ip, saddr.hostmask)
-      else:
-        saddr = 'host %s' % (saddr.ip)
-    if type(daddr) is nacaddr.IPv4 or type(daddr) is ipaddr.IPv4Network:
-      if daddr.numhosts > 1:
-        daddr = '%s %s' % (daddr.ip, daddr.hostmask)
-      else:
-        daddr = 'host %s' % (daddr.ip)
-    # inet6
-    if type(saddr) is nacaddr.IPv6 or type(saddr) is ipaddr.IPv6Network:
-      if saddr.numhosts > 1:
-        saddr = '%s' % (saddr.with_prefixlen)
-      else:
-        saddr = 'host %s' % (saddr.ip)
-    if type(daddr) is nacaddr.IPv6 or type(daddr) is ipaddr.IPv6Network:
-      if daddr.numhosts > 1:
-        daddr = '%s' % (daddr.with_prefixlen)
-      else:
-        daddr = 'host %s' % (daddr.ip)
+    saddr = self._AddressToStr(saddr)
+    daddr = self._AddressToStr(daddr)
 
     # fix ports
     if not sport:
       sport = ''
     elif sport[0] != sport[1]:
-      sport = 'range %d %d' % (sport[0], sport[1])
+      sport = ' range %s %s' % (self._TermPortToProtocol(sport[0],proto), self._TermPortToProtocol(sport[1],proto))
     else:
-      sport = 'eq %d' % (sport[0])
+      sport = ' eq %s' % (self._TermPortToProtocol(sport[0],proto))
 
     if not dport:
       dport = ''
     elif dport[0] != dport[1]:
-      dport = 'range %d %d' % (dport[0], dport[1])
+      dport = ' range %s %s' % (self._TermPortToProtocol(dport[0],proto), self._TermPortToProtocol(dport[1],proto))
     else:
-      dport = 'eq %d' % (dport[0])
+      dport = ' eq %s' % (self._TermPortToProtocol(dport[0],proto))
 
     if not option:
       option = ['']
@@ -573,7 +687,7 @@ class Term(aclgenerator.Term):
     ret_lines = []
 
     # str(icmp_type) is needed to ensure 0 maps to '0' instead of FALSE
-    icmp_type = str(icmp_type)
+    icmp_type = str(self._TermPortToProtocol(icmp_type,"icmp")) #str(icmp_type)
     if icmp_type:
       ret_lines.append(' %s %s %s %s %s %s %s %s' % (action, proto, saddr,
                                                      sport, daddr, dport,
@@ -632,6 +746,9 @@ class Cisco(aclgenerator.ACLGenerator):
                                       'routing_instance',
                                      ])
 
+  def _Term(self, term, af=4, proto_int=True):
+    return Term(term)
+ 
   def _TranslatePolicy(self, pol, exp_info):
     self.cisco_policies = []
     current_date = datetime.date.today()
@@ -662,6 +779,7 @@ class Cisco(aclgenerator.ACLGenerator):
                 filter_type, self._PLATFORM, str(good_filters)))
 
       filter_list = [filter_type]
+
       if filter_type == 'mixed':
         # Loop through filter and generate output for inet and inet6 in sequence
         filter_list = ['extended', 'inet6']
@@ -704,7 +822,7 @@ class Cisco(aclgenerator.ACLGenerator):
             # keep track of sequence numbers across terms
             new_terms.append(TermStandard(term, filter_name))
           elif next_filter == 'extended':
-            new_terms.append(Term(term, proto_int=self._PROTO_INT))
+            new_terms.append(self._Term(term, proto_int=self._PROTO_INT))
           elif next_filter == 'object-group':
             obj_target.AddTerm(term)
             new_terms.append(ObjectGroupTerm(term, filter_name))
@@ -755,9 +873,6 @@ class Cisco(aclgenerator.ACLGenerator):
   def __str__(self):
     target_header = []
     target = []
-    # add the p4 tags
-    target.extend(aclgenerator.AddRepositoryTags('! '))
-
     for (header, filter_name, filter_list, terms, obj_target
         ) in self.cisco_policies:
       for filter_type in filter_list:
@@ -780,7 +895,8 @@ class Cisco(aclgenerator.ACLGenerator):
         # add a header comment if one exists
         for comment in header.comment:
           for line in comment.split('\n'):
-            target.append('remark %s' % line)
+            target.append(' remark %s' % line)
+        target.append(' remark Filter type is %s' % (filter_type))
 
         # now add the terms
         for term in terms:
@@ -790,7 +906,8 @@ class Cisco(aclgenerator.ACLGenerator):
 
       if obj_target.valid:
         target = [str(obj_target)] + target
-      # ensure that the header is always first
+      
+     # ensure that the header is always first
       target = target_header + target
       target += ['', 'exit', '']
     return '\n'.join(target)

--- a/lib/ciscoasa.py
+++ b/lib/ciscoasa.py
@@ -67,7 +67,7 @@ class Term(aclgenerator.Term):
       if 'ciscoasa' in self.term.platform_exclude:
         return ''
 
-    ret_str = ['']
+    ret_str = ['\n']
 
     # Don't render icmpv6 protocol terms under inet, or icmp under inet6
     if ((self.af == 6 and 'icmp' in self.term.protocol) or

--- a/lib/ciscoasa.py
+++ b/lib/ciscoasa.py
@@ -67,7 +67,7 @@ class Term(aclgenerator.Term):
       if 'ciscoasa' in self.term.platform_exclude:
         return ''
 
-    ret_str = ['\n']
+    ret_str = ['']
 
     # Don't render icmpv6 protocol terms under inet, or icmp under inet6
     if ((self.af == 6 and 'icmp' in self.term.protocol) or
@@ -236,7 +236,8 @@ class Term(aclgenerator.Term):
 540: "uucp",
 43: "whois",
 80: "www",
-2049: "nfs"
+2049: "nfs",
+5060: "sip"
     }
     _ASA_PORTS_UDP = {
 512: "biff",
@@ -269,7 +270,8 @@ class Term(aclgenerator.Term):
 37: "time",
 513: "who",
 177: "xdmcp",
-2049: "nfs"
+2049: "nfs",
+5060: "sip"
     }
 
     _ASA_TYPES_ICMP = {

--- a/lib/cisconx.py
+++ b/lib/cisconx.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+#
+# Copyright 2011 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Cisco generator."""
+
+__author__ = 'antony@slac.stanford.edu (Antonio Ceseracciu)'
+
+import cisco
+import nacaddr
+from third_party import ipaddr
+
+class Term(cisco.Term):
+
+  _PLATFORM = 'cisconx'
+
+  def __init__(self, term, af=4, proto_int=True):
+    super(Term, self).__init__(term, af, proto_int)
+ 
+  def _AddressToStr(self, addr):
+    # inet4
+    if type(addr) is nacaddr.IPv4 or type(addr) is ipaddr.IPv4Network:
+      if addr.numhosts > 1:
+        addr = '%s' % (addr.with_prefixlen)
+      else:
+        addr = 'host %s' % (addr.ip)
+    # inet6
+    if type(addr) is nacaddr.IPv6 or type(addr) is ipaddr.IPv6Network:
+      if addr.numhosts > 1:
+        addr = '%s' % (addr.with_prefixlen)
+      else:
+        addr = 'host %s' % (addr.ip)
+    return addr
+
+
+class CiscoNX(cisco.Cisco):
+  """A cisco policy object."""
+
+  _PLATFORM = 'cisconx'
+  _DEFAULT_PROTOCOL = 'ip'
+  _SUFFIX = '.nacl'
+
+  def _Term(self, term, af=4, proto_int=True):
+    return Term(term)
+
+  def _AppendTargetByFilterType(self, filter_name, filter_type):
+    """Takes in the filter name and type and appends headers.
+
+    Args:
+      filter_name: Name of the current filter
+      filter_type: Type of current filter
+
+    Returns:
+      list of strings
+    """
+    target = []
+    if filter_type == 'inet6':
+      target.append('no ipv6 access-list %s' % filter_name)
+      target.append('ipv6 access-list %s' % filter_name)
+    else:
+      target.append('no ip access-list %s' % filter_name)
+      target.append('ip access-list %s' % filter_name)
+    return target
+

--- a/lib/yamlpolicyparser.py
+++ b/lib/yamlpolicyparser.py
@@ -116,7 +116,7 @@ class YamlPolicyParser(object):
       family = { 'ipv4': 'inet', 'ipv6': 'inet6' }
       ret.extend([family[addressfamily]])
       ret.extend(ta[1:])
-    elif ta[0] in ('demo', 'arista', 'brocade', 'ciscoxr', 'packetfilter'):
+    elif ta[0] in ('demo', 'arista', 'brocade', 'ciscoxr', 'cisconx', 'packetfilter'):
       ret = [ta[0], name]
       ret.extend(ta[1:])
     elif ta[0] in ('gce', 'ipset', 'speedway', 'ciscoasa', 'srx'):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from distutils.core import setup
 setup(name='capirca',
       maintainer='Google',
       maintainer_email='capirca-dev@googlegroups.com',
-      version='1.200',
+      version='1.2.1',
       url='https://github.com/google/capirca/',
       license='Apache License, Version 2.0',
       classifiers=[

--- a/test/characterization_data/filters_expected/sample_cisco_lab.acl
+++ b/test/characterization_data/filters_expected/sample_cisco_lab.acl
@@ -4,48 +4,48 @@
 no ip access-list extended allowtointernet
 ip access-list extended allowtointernet
 remark $Id:$
-remark Denies all traffic to internal IPs except established tcp replies.
-remark Also denies access to certain public allocations.
-remark Ideal for some internal lab/testing types of subnets that are
-remark not well trusted, but allowing internal users to access.
-remark Apply to ingress interface (to filter traffic coming from lab)
+ remark Denies all traffic to internal IPs except established tcp replies.
+ remark Also denies access to certain public allocations.
+ remark Ideal for some internal lab/testing types of subnets that are
+ remark not well trusted, but allowing internal users to access.
+ remark Apply to ingress interface (to filter traffic coming from lab)
 
 
-remark accept-dhcp
-remark Optional - allow forwarding of DHCP requests.
- permit 17 any any eq 67
- permit 17 any any eq 68
+ remark accept-dhcp
+ remark Optional - allow forwarding of DHCP requests.
+ permit udp any any eq bootps
+ permit udp any any eq bootpc
 
 
-remark accept-to-honestdns
-remark Allow name resolution using honestdns.
- permit 17 any host 8.8.4.4 eq 53
- permit 17 any host 8.8.8.8 eq 53
+ remark accept-to-honestdns
+ remark Allow name resolution using honestdns.
+ permit udp any host 8.8.4.4 eq domain
+ permit udp any host 8.8.8.8 eq domain
 
 
-remark accept-tcp-replies
-remark Allow tcp replies to internal hosts.
- permit 6 any 10.0.0.0 0.255.255.255 established
- permit 6 any 172.16.0.0 0.15.255.255 established
- permit 6 any 192.168.0.0 0.0.255.255 established
+ remark accept-tcp-replies
+ remark Allow tcp replies to internal hosts.
+ permit tcp any 10.0.0.0 0.255.255.255 established
+ permit tcp any 172.16.0.0 0.15.255.255 established
+ permit tcp any 192.168.0.0 0.0.255.255 established
 
 
-remark deny-to-internal
-remark Deny access to rfc1918/internal.
+ remark deny-to-internal
+ remark Deny access to rfc1918/internal.
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark deny-to-specific_hosts
-remark Deny access to specified public.
+ remark deny-to-specific_hosts
+ remark Deny access to specified public.
  deny ip any host 200.1.1.1
  deny ip any host 200.1.1.2
  deny ip any 200.1.1.4 0.0.0.1
 
 
-remark default-permit
-remark Allow what's left.
+ remark default-permit
+ remark Allow what's left.
  permit ip any any
 
 exit

--- a/test/characterization_data/filters_expected/sample_multitarget.acl
+++ b/test/characterization_data/filters_expected/sample_multitarget.acl
@@ -4,14 +4,14 @@
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit 6 any 200.1.1.4 0.0.0.1 eq 25
- permit 6 any 200.1.1.4 0.0.0.1 eq 465
- permit 6 any 200.1.1.4 0.0.0.1 eq 587
- permit 6 any 200.1.1.4 0.0.0.1 eq 995
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
+ permit tcp any 200.1.1.4 0.0.0.1 eq 465
+ permit tcp any 200.1.1.4 0.0.0.1 eq 587
+ permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit 6 any host 200.1.1.1 eq 80
- permit 6 any host 200.1.1.1 eq 443
- permit 6 any host 200.1.1.2 eq 80
- permit 6 any host 200.1.1.2 eq 443
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
- permit 6 any host 200.1.1.1 established
- permit 6 any 200.1.1.2 0.0.0.1 established
- permit 6 any 200.1.1.4 0.0.0.1 established
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2 0.0.0.1 established
+ permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
- permit 17 any range 1024 65535 host 200.1.1.1
- permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
- permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2 0.0.0.1
+ permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit
@@ -72,27 +72,27 @@ exit
 no ipv6 access-list ipv6-edge-inbound
 ipv6 access-list ipv6-edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ipv6 2001:db8::/32 any
  deny ipv6 3ffe::/16 any
  deny ipv6 5f00::/8 any
  deny ipv6 ff00::/8 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ipv6 ::/3 any
  deny ipv6 4000::/2 any
  deny ipv6 8000::/1 any
 
 
-remark default-deny
+ remark default-deny
  deny ipv6 any any
 
 exit
@@ -100,10 +100,10 @@ exit
 no ip access-list extended edge-outbound
 ip access-list extended edge-outbound
 remark $Id:$
-remark this is a sample output filter
+ remark this is a sample output filter
 
 
-remark deny-to-bad-destinations
+ remark deny-to-bad-destinations
  deny ip any 0.0.0.0 0.255.255.255
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 100.64.0.0 0.63.255.255
@@ -119,7 +119,7 @@ remark deny-to-bad-destinations
  deny ip any 224.0.0.0 31.255.255.255
 
 
-remark default-accept
+ remark default-accept
  permit ip any any
 
 exit
@@ -127,10 +127,10 @@ exit
 no ipv6 access-list ipv6-edge-outbound
 ipv6 access-list ipv6-edge-outbound
 remark $Id:$
-remark this is a sample output filter
+ remark this is a sample output filter
 
 
-remark deny-to-bad-destinations
+ remark deny-to-bad-destinations
  deny ipv6 any ::/3
  deny ipv6 any 2001:db8::/32
  deny ipv6 any 3ffe::/16
@@ -138,7 +138,7 @@ remark deny-to-bad-destinations
  deny ipv6 any 8000::/1
 
 
-remark default-accept
+ remark default-accept
  permit ipv6 any any
 
 exit

--- a/test/characterization_data/filters_expected/sample_multitarget.bacl
+++ b/test/characterization_data/filters_expected/sample_multitarget.bacl
@@ -4,14 +4,14 @@
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit tcp any 200.1.1.4 0.0.0.1 eq 25
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
  permit tcp any 200.1.1.4 0.0.0.1 eq 465
  permit tcp any 200.1.1.4 0.0.0.1 eq 587
  permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit tcp any host 200.1.1.1 eq 80
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
  permit tcp any host 200.1.1.1 eq 443
- permit tcp any host 200.1.1.2 eq 80
+ permit tcp any host 200.1.1.2 eq www
  permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit tcp any host 200.1.1.1 established
  permit tcp any 200.1.1.2 0.0.0.1 established
  permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit udp any range 1024 65535 host 200.1.1.1
  permit udp any range 1024 65535 200.1.1.2 0.0.0.1
  permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/characterization_data/filters_expected/sample_multitarget.eacl
+++ b/test/characterization_data/filters_expected/sample_multitarget.eacl
@@ -4,14 +4,14 @@
 no ip access-list edge-inbound
 ip access-list edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit tcp any 200.1.1.4 0.0.0.1 eq 25
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
  permit tcp any 200.1.1.4 0.0.0.1 eq 465
  permit tcp any 200.1.1.4 0.0.0.1 eq 587
  permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit tcp any host 200.1.1.1 eq 80
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
  permit tcp any host 200.1.1.1 eq 443
- permit tcp any host 200.1.1.2 eq 80
+ permit tcp any host 200.1.1.2 eq www
  permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit tcp any host 200.1.1.1 established
  permit tcp any 200.1.1.2 0.0.0.1 established
  permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit udp any range 1024 65535 host 200.1.1.1
  permit udp any range 1024 65535 200.1.1.2 0.0.0.1
  permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/characterization_data/filters_expected/sample_multitarget.nacl
+++ b/test/characterization_data/filters_expected/sample_multitarget.nacl
@@ -1,0 +1,70 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list edge-inbound
+ip access-list edge-inbound
+remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
+
+
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
+ deny ip 0.0.0.0/8 any
+ deny ip 192.0.0.0/24 any
+ deny ip 192.0.2.0/24 any
+ deny ip 198.18.0.0/15 any
+ deny ip 198.51.100.0/24 any
+ deny ip 203.0.113.0/24 any
+ deny ip 224.0.0.0/3 any
+
+
+ remark deny-from-reserved
+ deny ip 0.0.0.0/8 any
+ deny ip 10.0.0.0/8 any
+ deny ip 100.64.0.0/10 any
+ deny ip 127.0.0.0/8 any
+ deny ip 169.254.0.0/16 any
+ deny ip 172.16.0.0/12 any
+ deny ip 192.168.0.0/16 any
+ deny ip 224.0.0.0/3 any
+
+
+ remark deny-to-rfc1918
+ deny ip any 10.0.0.0/8
+ deny ip any 172.16.0.0/12
+ deny ip any 192.168.0.0/16
+
+
+ remark permit-mail-services
+ permit tcp any 200.1.1.4/31 eq smtp
+ permit tcp any 200.1.1.4/31 eq 465
+ permit tcp any 200.1.1.4/31 eq 587
+ permit tcp any 200.1.1.4/31 eq 995
+
+
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
+
+
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2/31 established
+ permit tcp any 200.1.1.4/31 established
+
+
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2/31
+ permit udp any range 1024 65535 200.1.1.4/31
+
+
+ remark default-deny
+ deny ip any any
+
+exit

--- a/test/characterization_data/filters_expected/sample_multitarget.xacl
+++ b/test/characterization_data/filters_expected/sample_multitarget.xacl
@@ -4,14 +4,14 @@
 no ipv4 access-list edge-inbound
 ipv4 access-list edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit 6 any 200.1.1.4 0.0.0.1 eq 25
- permit 6 any 200.1.1.4 0.0.0.1 eq 465
- permit 6 any 200.1.1.4 0.0.0.1 eq 587
- permit 6 any 200.1.1.4 0.0.0.1 eq 995
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
+ permit tcp any 200.1.1.4 0.0.0.1 eq 465
+ permit tcp any 200.1.1.4 0.0.0.1 eq 587
+ permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit 6 any host 200.1.1.1 eq 80
- permit 6 any host 200.1.1.1 eq 443
- permit 6 any host 200.1.1.2 eq 80
- permit 6 any host 200.1.1.2 eq 443
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
- permit 6 any host 200.1.1.1 established
- permit 6 any 200.1.1.2 0.0.0.1 established
- permit 6 any 200.1.1.4 0.0.0.1 established
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2 0.0.0.1 established
+ permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
- permit 17 any range 1024 65535 host 200.1.1.1
- permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
- permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2 0.0.0.1
+ permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/characterization_data/policies/sample_multitarget.pol
+++ b/test/characterization_data/policies/sample_multitarget.pol
@@ -15,6 +15,7 @@ header {
   target:: arista edge-inbound
   target:: brocade edge-inbound
   target:: ciscoxr edge-inbound
+  target:: cisconx edge-inbound
 }
 
 #include 'includes/untrusted-networks-blocking.inc'

--- a/test/integration/test_aclgen.py
+++ b/test/integration/test_aclgen.py
@@ -185,7 +185,12 @@ class AclGen_Create_filter_for_target(AclGen_Characterization_Test_Base):
     actual_filter = str(fw)
     with open(self.testpath('filters_expected', 'sample_cisco_lab.acl'), 'r') as f:
       expected_filter = f.read()
-    self.assertEquals(actual_filter, expected_filter)
+
+    # If different, save for manual check.
+    if (actual_filter != expected_filter):
+      with open(self.testpath('filters_actual', 'sample_cisco_lab.acl'), 'w') as f:
+        f.write(actual_filter)
+    self.assertEqual(actual_filter, expected_filter)
 
   def test_generating_filter_for_missing_platform_throws(self):
     a = self.get_acl_gen()

--- a/test/yaml_policies/filters_expected/sample_cisco_lab.acl
+++ b/test/yaml_policies/filters_expected/sample_cisco_lab.acl
@@ -4,48 +4,48 @@
 no ip access-list extended allowtointernet
 ip access-list extended allowtointernet
 remark $Id:$
-remark Denies all traffic to internal IPs except established tcp replies.
-remark Also denies access to certain public allocations.
-remark Ideal for some internal lab/testing types of subnets that are
-remark not well trusted, but allowing internal users to access.
-remark Apply to ingress interface (to filter traffic coming from lab)
+ remark Denies all traffic to internal IPs except established tcp replies.
+ remark Also denies access to certain public allocations.
+ remark Ideal for some internal lab/testing types of subnets that are
+ remark not well trusted, but allowing internal users to access.
+ remark Apply to ingress interface (to filter traffic coming from lab)
 
 
-remark accept-dhcp
-remark Optional - allow forwarding of DHCP requests.
- permit 17 any any eq 67
- permit 17 any any eq 68
+ remark accept-dhcp
+ remark Optional - allow forwarding of DHCP requests.
+ permit udp any any eq bootps
+ permit udp any any eq bootpc
 
 
-remark accept-to-honestdns
-remark Allow name resolution using honestdns.
- permit 17 any host 8.8.4.4 eq 53
- permit 17 any host 8.8.8.8 eq 53
+ remark accept-to-honestdns
+ remark Allow name resolution using honestdns.
+ permit udp any host 8.8.4.4 eq domain
+ permit udp any host 8.8.8.8 eq domain
 
 
-remark accept-tcp-replies
-remark Allow tcp replies to internal hosts.
- permit 6 any 10.0.0.0 0.255.255.255 established
- permit 6 any 172.16.0.0 0.15.255.255 established
- permit 6 any 192.168.0.0 0.0.255.255 established
+ remark accept-tcp-replies
+ remark Allow tcp replies to internal hosts.
+ permit tcp any 10.0.0.0 0.255.255.255 established
+ permit tcp any 172.16.0.0 0.15.255.255 established
+ permit tcp any 192.168.0.0 0.0.255.255 established
 
 
-remark deny-to-internal
-remark Deny access to rfc1918/internal.
+ remark deny-to-internal
+ remark Deny access to rfc1918/internal.
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark deny-to-specific_hosts
-remark Deny access to specified public.
+ remark deny-to-specific_hosts
+ remark Deny access to specified public.
  deny ip any host 200.1.1.1
  deny ip any host 200.1.1.2
  deny ip any 200.1.1.4 0.0.0.1
 
 
-remark default-permit
-remark Allow what's left.
+ remark default-permit
+ remark Allow what's left.
  permit ip any any
 
 exit

--- a/test/yaml_policies/filters_expected/sample_multitarget.acl
+++ b/test/yaml_policies/filters_expected/sample_multitarget.acl
@@ -4,14 +4,14 @@
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit 6 any 200.1.1.4 0.0.0.1 eq 25
- permit 6 any 200.1.1.4 0.0.0.1 eq 465
- permit 6 any 200.1.1.4 0.0.0.1 eq 587
- permit 6 any 200.1.1.4 0.0.0.1 eq 995
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
+ permit tcp any 200.1.1.4 0.0.0.1 eq 465
+ permit tcp any 200.1.1.4 0.0.0.1 eq 587
+ permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit 6 any host 200.1.1.1 eq 80
- permit 6 any host 200.1.1.1 eq 443
- permit 6 any host 200.1.1.2 eq 80
- permit 6 any host 200.1.1.2 eq 443
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
- permit 6 any host 200.1.1.1 established
- permit 6 any 200.1.1.2 0.0.0.1 established
- permit 6 any 200.1.1.4 0.0.0.1 established
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2 0.0.0.1 established
+ permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
- permit 17 any range 1024 65535 host 200.1.1.1
- permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
- permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2 0.0.0.1
+ permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/yaml_policies/filters_expected/sample_multitarget.bacl
+++ b/test/yaml_policies/filters_expected/sample_multitarget.bacl
@@ -4,14 +4,14 @@
 no ip access-list extended edge-inbound
 ip access-list extended edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit tcp any 200.1.1.4 0.0.0.1 eq 25
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
  permit tcp any 200.1.1.4 0.0.0.1 eq 465
  permit tcp any 200.1.1.4 0.0.0.1 eq 587
  permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit tcp any host 200.1.1.1 eq 80
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
  permit tcp any host 200.1.1.1 eq 443
- permit tcp any host 200.1.1.2 eq 80
+ permit tcp any host 200.1.1.2 eq www
  permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit tcp any host 200.1.1.1 established
  permit tcp any 200.1.1.2 0.0.0.1 established
  permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit udp any range 1024 65535 host 200.1.1.1
  permit udp any range 1024 65535 200.1.1.2 0.0.0.1
  permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/yaml_policies/filters_expected/sample_multitarget.eacl
+++ b/test/yaml_policies/filters_expected/sample_multitarget.eacl
@@ -4,14 +4,14 @@
 no ip access-list edge-inbound
 ip access-list edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit tcp any 200.1.1.4 0.0.0.1 eq 25
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
  permit tcp any 200.1.1.4 0.0.0.1 eq 465
  permit tcp any 200.1.1.4 0.0.0.1 eq 587
  permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit tcp any host 200.1.1.1 eq 80
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
  permit tcp any host 200.1.1.1 eq 443
- permit tcp any host 200.1.1.2 eq 80
+ permit tcp any host 200.1.1.2 eq www
  permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
+ remark permit-tcp-established
  permit tcp any host 200.1.1.1 established
  permit tcp any 200.1.1.2 0.0.0.1 established
  permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
+ remark permit-udp-established
  permit udp any range 1024 65535 host 200.1.1.1
  permit udp any range 1024 65535 200.1.1.2 0.0.0.1
  permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/yaml_policies/filters_expected/sample_multitarget.nacl
+++ b/test/yaml_policies/filters_expected/sample_multitarget.nacl
@@ -1,0 +1,70 @@
+! $Id:$
+! $Date:$
+! $Revision:$
+no ip access-list edge-inbound
+ip access-list edge-inbound
+remark $Id:$
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
+
+
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
+ deny ip 0.0.0.0/8 any
+ deny ip 192.0.0.0/24 any
+ deny ip 192.0.2.0/24 any
+ deny ip 198.18.0.0/15 any
+ deny ip 198.51.100.0/24 any
+ deny ip 203.0.113.0/24 any
+ deny ip 224.0.0.0/3 any
+
+
+ remark deny-from-reserved
+ deny ip 0.0.0.0/8 any
+ deny ip 10.0.0.0/8 any
+ deny ip 100.64.0.0/10 any
+ deny ip 127.0.0.0/8 any
+ deny ip 169.254.0.0/16 any
+ deny ip 172.16.0.0/12 any
+ deny ip 192.168.0.0/16 any
+ deny ip 224.0.0.0/3 any
+
+
+ remark deny-to-rfc1918
+ deny ip any 10.0.0.0/8
+ deny ip any 172.16.0.0/12
+ deny ip any 192.168.0.0/16
+
+
+ remark permit-mail-services
+ permit tcp any 200.1.1.4/31 eq smtp
+ permit tcp any 200.1.1.4/31 eq 465
+ permit tcp any 200.1.1.4/31 eq 587
+ permit tcp any 200.1.1.4/31 eq 995
+
+
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
+
+
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2/31 established
+ permit tcp any 200.1.1.4/31 established
+
+
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2/31
+ permit udp any range 1024 65535 200.1.1.4/31
+
+
+ remark default-deny
+ deny ip any any
+
+exit

--- a/test/yaml_policies/filters_expected/sample_multitarget.xacl
+++ b/test/yaml_policies/filters_expected/sample_multitarget.xacl
@@ -4,14 +4,14 @@
 no ipv4 access-list edge-inbound
 ipv4 access-list edge-inbound
 remark $Id:$
-remark this is a sample edge input filter that generates
-remark multiple output formats.
+ remark this is a sample edge input filter that generates
+ remark multiple output formats.
 
 
-remark deny-from-bogons
-remark this is a sample edge input filter with a very very very long and
-remark multi-line comment that
-remark also has multiple entries.
+ remark deny-from-bogons
+ remark this is a sample edge input filter with a very very very long and
+ remark multi-line comment that
+ remark also has multiple entries.
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 192.0.0.0 0.0.0.255 any
  deny ip 192.0.2.0 0.0.0.255 any
@@ -21,7 +21,7 @@ remark also has multiple entries.
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-from-reserved
+ remark deny-from-reserved
  deny ip 0.0.0.0 0.255.255.255 any
  deny ip 10.0.0.0 0.255.255.255 any
  deny ip 100.64.0.0 0.63.255.255 any
@@ -32,39 +32,39 @@ remark deny-from-reserved
  deny ip 224.0.0.0 31.255.255.255 any
 
 
-remark deny-to-rfc1918
+ remark deny-to-rfc1918
  deny ip any 10.0.0.0 0.255.255.255
  deny ip any 172.16.0.0 0.15.255.255
  deny ip any 192.168.0.0 0.0.255.255
 
 
-remark permit-mail-services
- permit 6 any 200.1.1.4 0.0.0.1 eq 25
- permit 6 any 200.1.1.4 0.0.0.1 eq 465
- permit 6 any 200.1.1.4 0.0.0.1 eq 587
- permit 6 any 200.1.1.4 0.0.0.1 eq 995
+ remark permit-mail-services
+ permit tcp any 200.1.1.4 0.0.0.1 eq smtp
+ permit tcp any 200.1.1.4 0.0.0.1 eq 465
+ permit tcp any 200.1.1.4 0.0.0.1 eq 587
+ permit tcp any 200.1.1.4 0.0.0.1 eq 995
 
 
-remark permit-web-services
- permit 6 any host 200.1.1.1 eq 80
- permit 6 any host 200.1.1.1 eq 443
- permit 6 any host 200.1.1.2 eq 80
- permit 6 any host 200.1.1.2 eq 443
+ remark permit-web-services
+ permit tcp any host 200.1.1.1 eq www
+ permit tcp any host 200.1.1.1 eq 443
+ permit tcp any host 200.1.1.2 eq www
+ permit tcp any host 200.1.1.2 eq 443
 
 
-remark permit-tcp-established
- permit 6 any host 200.1.1.1 established
- permit 6 any 200.1.1.2 0.0.0.1 established
- permit 6 any 200.1.1.4 0.0.0.1 established
+ remark permit-tcp-established
+ permit tcp any host 200.1.1.1 established
+ permit tcp any 200.1.1.2 0.0.0.1 established
+ permit tcp any 200.1.1.4 0.0.0.1 established
 
 
-remark permit-udp-established
- permit 17 any range 1024 65535 host 200.1.1.1
- permit 17 any range 1024 65535 200.1.1.2 0.0.0.1
- permit 17 any range 1024 65535 200.1.1.4 0.0.0.1
+ remark permit-udp-established
+ permit udp any range 1024 65535 host 200.1.1.1
+ permit udp any range 1024 65535 200.1.1.2 0.0.0.1
+ permit udp any range 1024 65535 200.1.1.4 0.0.0.1
 
 
-remark default-deny
+ remark default-deny
  deny ip any any
 
 exit

--- a/test/yaml_policies/policies/sample_multitarget.yml
+++ b/test/yaml_policies/policies/sample_multitarget.yml
@@ -18,6 +18,7 @@ targets:
   - arista
   - brocade
   - ciscoxr
+  - cisconx
 
 terms:
 


### PR DESCRIPTION
Taking code from [@nyanto's public fork](https://github.com/nyanto/capirca/commit/c2d6c888cb5b1e0e5d888c127c034bdc12ba272f), reused with permission.

Add simple test coverage and fix existing regression tests.
