### PR TITLE
lib should log to NullHandler by default.

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -31,3 +31,14 @@ __all__ = ['naming', 'yamlnaming', 'policy', 'cisco', 'cisconx', 'juniper', 'ipt
            'packetfilter', 'port', 'speedway', 'gce']
 
 __author__ = 'Paul (Tony) Watson (watson@gmail.com / watson@google.com)'
+
+# Set default logging handler to avoid "No handler found" warnings.
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logging.getLogger(__name__).addHandler(NullHandler())


### PR DESCRIPTION
Capirca classes could potentially be exposed as a library for use via Ansible
or similar.  Libraries should use NullHandler for loggers by default.  ref
http://docs.python-guide.org/en/latest/writing/logging/ for discussion.
